### PR TITLE
Remove Consensus from Block publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # Exclude IDE and Editor files
 /.idea/
 *.sublime*
+**/.vscode/
 
 # Exclude poet build artifacts
 /consensus/**/__pycache__/

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -253,12 +253,6 @@ class BlockPublisher(OwnedPointer):
 
         return (c_length.value, c_limit.value)
 
-    def on_check_publish_block(self, force=False):
-
-        self._py_call(
-            'on_check_publish_block',
-            ctypes.c_bool(force))
-
     def on_batch_received(self, batch):
         self._py_call(
             'on_batch_received',

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -33,8 +33,7 @@ use pylogger;
 use scheduler::Scheduler;
 
 pub enum CandidateBlockError {
-    ConsensusNotReady,
-    NoPendingBatchesRemaining,
+    BlockEmpty,
 }
 
 pub struct FinalizeBlockResult {
@@ -331,7 +330,7 @@ impl CandidateBlock {
 
     pub fn finalize(&mut self, force: bool) -> Result<FinalizeBlockResult, CandidateBlockError> {
         if !(force || !self.pending_batches.is_empty()) {
-            return Err(CandidateBlockError::NoPendingBatchesRemaining);
+            return Err(CandidateBlockError::BlockEmpty);
         }
 
         self.scheduler.finalize(true).unwrap();
@@ -467,7 +466,7 @@ impl CandidateBlock {
                     .collect::<Vec<String>>(),
             })
         } else {
-            Err(CandidateBlockError::NoPendingBatchesRemaining)
+            Err(CandidateBlockError::BlockEmpty)
         }
     }
 }

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -44,22 +44,6 @@ lazy_static! {
         metrics::get_collector("sawtooth_validator.publisher");
 }
 
-/// Collects and tracks the changes in various states of the
-/// Publisher. For example it tracks `consensus_ready`,
-/// which denotes entering or exiting this state.
-#[derive(Clone)]
-struct PublisherLoggingStates {
-    consensus_ready: bool,
-}
-
-impl PublisherLoggingStates {
-    fn new() -> Self {
-        PublisherLoggingStates {
-            consensus_ready: true,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum InitializeBlockError {
     ConsensusNotReady,
@@ -83,7 +67,6 @@ pub struct BlockPublisherState {
     pub chain_head: Option<BlockWrapper>,
     pub candidate_block: Option<CandidateBlock>,
     pub pending_batches: PendingBatchesPool,
-    publisher_logging_states: PublisherLoggingStates,
 }
 
 impl BlockPublisherState {
@@ -98,7 +81,6 @@ impl BlockPublisherState {
             chain_head,
             candidate_block,
             pending_batches,
-            publisher_logging_states: PublisherLoggingStates::new(),
         }
     }
 }
@@ -109,7 +91,6 @@ pub struct SyncBlockPublisher {
     check_publish_block_frequency: Duration,
     batch_observers: Vec<PyObject>,
     batch_injector_factory: PyObject,
-    consensus_factory: PyObject,
     block_wrapper_class: PyObject,
     block_header_class: PyObject,
     block_builder_class: PyObject,
@@ -142,7 +123,6 @@ impl Clone for SyncBlockPublisher {
                 .map(|i| i.clone_ref(py))
                 .collect(),
             batch_injector_factory: self.batch_injector_factory.clone_ref(py),
-            consensus_factory: self.consensus_factory.clone_ref(py),
             block_wrapper_class: self.block_wrapper_class.clone_ref(py),
             block_header_class: self.block_header_class.clone_ref(py),
             block_builder_class: self.block_builder_class.clone_ref(py),
@@ -255,8 +235,6 @@ impl SyncBlockPublisher {
 
             let state_view = self.get_state_view(py, previous_block);
             let public_key = self.get_public_key(py);
-            let consensus =
-                self.load_consensus(py, previous_block, &state_view, public_key.clone());
             let batch_injectors = self.load_injectors(py, &previous_block.block.header_signature);
 
             let kwargs = PyDict::new(py);
@@ -281,21 +259,6 @@ impl SyncBlockPublisher {
                 .call(py, (block_header,), None)
                 .expect("BlockBuilder could not be constructed");
 
-            let consensus_check: bool = consensus
-                .call_method(
-                    py,
-                    "initialize_block",
-                    (block_builder.getattr(py, "block_header").unwrap(),),
-                    None,
-                )
-                .expect("Call to consensus.initialize_block failed")
-                .extract(py)
-                .unwrap();
-
-            if !consensus_check {
-                return Err(InitializeBlockError::ConsensusNotReady);
-            }
-
             let scheduler = state
                 .transaction_executor
                 .create_scheduler(&previous_block.block.state_root_hash)
@@ -313,7 +276,6 @@ impl SyncBlockPublisher {
 
             CandidateBlock::new(
                 block_store,
-                consensus,
                 scheduler,
                 committed_txn_cache,
                 block_builder,
@@ -395,48 +357,6 @@ impl SyncBlockPublisher {
         self.on_chain_updated(state, None, Vec::new(), Vec::new());
     }
 
-    fn load_consensus(
-        &self,
-        py: Python,
-        block: &BlockWrapper,
-        state_view: &PyObject,
-        public_key: String,
-    ) -> PyObject {
-        let kwargs = PyDict::new(py);
-        kwargs
-            .set_item(py, "block_cache", self.block_cache.clone_ref(py))
-            .unwrap();
-        kwargs
-            .set_item(
-                py,
-                "state_view_factory",
-                self.state_view_factory.clone_ref(py),
-            )
-            .unwrap();
-        kwargs
-            .set_item(py, "batch_publisher", self.batch_publisher.clone_ref(py))
-            .unwrap();
-        kwargs
-            .set_item(py, "data_dir", self.data_dir.clone_ref(py))
-            .unwrap();
-        kwargs
-            .set_item(py, "config_dir", self.config_dir.clone_ref(py))
-            .unwrap();
-        kwargs
-            .set_item(py, "validator_id", public_key.clone())
-            .unwrap();
-        let consensus_block_publisher = self.consensus_factory
-            .call_method(
-                py,
-                "get_configured_consensus_module",
-                (block.header_signature(), state_view),
-                None,
-            )
-            .expect("ConsensusFactory has no method get_configured_consensus_module")
-            .call_method(py, "BlockPublisher", NoArgs, Some(&kwargs));
-        consensus_block_publisher.unwrap()
-    }
-
     fn get_public_key(&self, py: Python) -> String {
         self.identity_signer
             .call_method(py, "get_public_key", NoArgs, None)
@@ -453,20 +373,6 @@ impl SyncBlockPublisher {
 
     fn can_build_block(&self, state: &BlockPublisherState) -> bool {
         state.chain_head.is_some() && state.pending_batches.len() > 0
-    }
-
-    fn log_consensus_state(&self, state: &mut BlockPublisherState, ready: bool) {
-        if ready {
-            if !state.publisher_logging_states.consensus_ready {
-                state.publisher_logging_states.consensus_ready = true;
-                debug!("Consensus is ready to build candidate block");
-            }
-        } else {
-            if state.publisher_logging_states.consensus_ready {
-                state.publisher_logging_states.consensus_ready = false;
-                debug!("Consensus not ready to build candidate block");
-            }
-        }
     }
 
     pub fn on_batch_received(&self, batch: Batch) {
@@ -505,10 +411,7 @@ impl SyncBlockPublisher {
         if !self.is_building_block(&state) && self.can_build_block(&state) {
             let chain_head = state.chain_head.clone().unwrap();
             match self.initialize_block(&mut state, &chain_head) {
-                Ok(_) => self.log_consensus_state(&mut state, true),
-                Err(InitializeBlockError::ConsensusNotReady) => {
-                    self.log_consensus_state(&mut state, false)
-                }
+                _ => {}
                 Err(InitializeBlockError::InvalidState) => {
                     warn!("Tried to initialize block but block already initialized.")
                 }
@@ -562,7 +465,6 @@ impl BlockPublisher {
         check_publish_block_frequency: Duration,
         batch_observers: Vec<PyObject>,
         batch_injector_factory: PyObject,
-        consensus_factory: PyObject,
         block_wrapper_class: PyObject,
         block_header_class: PyObject,
         block_builder_class: PyObject,
@@ -592,7 +494,6 @@ impl BlockPublisher {
             check_publish_block_frequency,
             batch_observers,
             batch_injector_factory,
-            consensus_factory,
             block_wrapper_class,
             block_header_class,
             block_builder_class,

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -119,10 +119,6 @@ pub extern "C" fn block_publisher_new(
         )
         .expect("Unable to create BatchPublisher");
 
-    let consensus_factory_mod = py.import("sawtooth_validator.journal.consensus.consensus_factory")
-        .expect("Unable to import 'sawtooth_validator.journal.consensus.consensus_factory'");
-    let consensus_factory = consensus_factory_mod.get(py, "ConsensusFactory").unwrap();
-
     let block_wrapper_mod = py.import("sawtooth_validator.journal.block_wrapper")
         .expect("Unable to import 'sawtooth_validator.journal.block_wrapper'");
 
@@ -160,7 +156,6 @@ pub extern "C" fn block_publisher_new(
         check_publish_block_frequency,
         batch_observers,
         batch_injector_factory,
-        consensus_factory,
         block_wrapper_class,
         block_header_class,
         block_builder_class,
@@ -178,21 +173,6 @@ pub extern "C" fn block_publisher_new(
 pub extern "C" fn block_publisher_drop(publisher: *mut c_void) -> ErrorCode {
     check_null!(publisher);
     unsafe { Box::from_raw(publisher as *mut BlockPublisher) };
-    ErrorCode::Success
-}
-
-// block_publisher_on_check_publish_block is used in tests
-#[no_mangle]
-pub extern "C" fn block_publisher_on_check_publish_block(
-    publisher: *mut c_void,
-    force: bool,
-) -> ErrorCode {
-    check_null!(publisher);
-    unsafe {
-        (*(publisher as *mut BlockPublisher))
-            .publisher
-            .on_check_publish_block(force)
-    };
     ErrorCode::Success
 }
 


### PR DESCRIPTION
There is still an import of consensus.BatchSender python class, but this is used also to send out BlockInfo injected batches.