### PR TITLE
Add loading of log configuration

### DIFF
--- a/sdk/examples/poet_python/sawtooth_poet_engine/main.py
+++ b/sdk/examples/poet_python/sawtooth_poet_engine/main.py
@@ -79,12 +79,19 @@ def main(args=None):
     opts = parse_args(args)
 
     try:
-        log_dir = get_log_dir()
-        log_configuration(
-            log_dir=log_dir,
-            name='poet-engine')
+        log_config = get_log_config('poet-engine-log-config.toml')
+        if log_config is None:
+            log_config = get_log_config('poet-engine-log-config.yaml')
 
-        init_console_logging(verbose_level=opts.verbose)
+        if log_config is not None:
+            log_configuration(log_config=log_config)
+            if log_config.get('root') is not None:
+                init_console_logging(verbose_level=opts.verbose)
+        else:
+            log_dir = get_log_dir()
+            log_configuration(
+                log_dir=log_dir,
+                name='poet-engine')
 
         driver = ZmqDriver(
             PoetEngine(


### PR DESCRIPTION
Add loading of config files for the PoET engine. This will allow for
broader configuration of the logging subsystem.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>