### PR TITLE
Update validator deb builds for change to poet-core

### DIFF
--- a/validator/Dockerfile-installed
+++ b/validator/Dockerfile-installed
@@ -128,6 +128,41 @@ RUN /project/bin/protogen \
  && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
  && dpkg-buildpackage -b -rfakeroot -us -uc
 
+# -------------=== python sdk build ===-------------
+
+FROM ubuntu:xenial as sawtooth-sdk-python-builder
+
+ENV VERSION=AUTO_STRICT
+
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && apt-get update \
+ && apt-get install -y -q --allow-downgrades \
+    git \
+    python3 \
+    python3-colorlog \
+    python3-protobuf \
+    python3-stdeb \
+    python3-grpcio-tools \
+    python3-grpcio \
+    python3-toml \
+    python3-yaml
+
+COPY --from=sawtooth-signing-builder /project/python3-sawtooth-signing*.deb /tmp
+
+COPY . /project
+
+RUN dpkg -i /tmp/python3-sawtooth-*.deb || true \
+ && apt-get -f -y install \
+ && /project/bin/protogen \
+ && cd /project/sdk/python \
+ && if [ -d "debian" ]; then rm -rf debian; fi \
+ && python3 setup.py clean --all \
+ && python3 setup.py --command-packages=stdeb.command debianize \
+ && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
+ && dpkg-buildpackage -b -rfakeroot -us -uc
+
 # -------------=== poet common build ===-------------
 
 FROM ubuntu:xenial as poet-common-builder
@@ -145,9 +180,13 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     python3-protobuf \
     python3-stdeb
 
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
+
 COPY . /project
 
-RUN /project/bin/protogen \
+RUN dpkg -i /tmp/python3-sawtooth-*.deb || true \
+ && apt-get -f -y install \
+ && /project/bin/protogen \
  && cd /project/consensus/poet/common/ \
  && if [ -d "debian" ]; then rm -rf debian; fi \
  && python3 setup.py clean --all \
@@ -176,7 +215,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
 
 COPY --from=sawtooth-signing-builder /project/python3-sawtooth-signing*.deb /tmp
 COPY --from=poet-common-builder /project/consensus/poet/python3-sawtooth-poet-common*.deb /tmp
-COPY --from=sawtooth-validator-builder /project/python3-sawtooth-validator*.deb /tmp
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
 
 COPY . /project
 
@@ -203,15 +242,17 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  && apt-get install -y -q --allow-downgrades \
     git \
     python3 \
+    python3-cbor \
     python3-grpcio-tools \
     python3-grpcio \
+    python3-lmdb \
     python3-protobuf \
     python3-requests \
     python3-stdeb
 
 COPY --from=sawtooth-signing-builder /project/python3-sawtooth-signing*.deb /tmp
 COPY --from=poet-common-builder /project/consensus/poet/python3-sawtooth-poet-common*.deb /tmp
-COPY --from=sawtooth-validator-builder /project/python3-sawtooth-validator*.deb /tmp
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
 COPY --from=sawtooth-simulator-builder /project/consensus/poet/python3-sawtooth-poet-simulator*.deb /tmp
 
 COPY . /project
@@ -239,6 +280,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  && apt-get install -y -q --allow-downgrades \
     git \
     python3 \
+    python3-cbor \
     python3-colorlog \
     python3-grpcio-tools \
     python3-grpcio \
@@ -248,7 +290,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
 
 COPY --from=sawtooth-signing-builder /project/python3-sawtooth-signing*.deb /tmp
 COPY --from=poet-common-builder /project/consensus/poet/python3-sawtooth-poet-common*.deb /tmp
-COPY --from=sawtooth-validator-builder /project/python3-sawtooth-validator*.deb /tmp
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
 COPY --from=sawtooth-simulator-builder /project/consensus/poet/python3-sawtooth-poet-simulator*.deb /tmp
 COPY --from=poet-core-builder /project/consensus/poet/python3-sawtooth-poet-core*.deb /tmp
 
@@ -274,6 +316,7 @@ COPY --from=poet-common-builder /project/consensus/poet/python3-sawtooth-poet-co
 COPY --from=sawtooth-simulator-builder /project/consensus/poet/python3-sawtooth-poet-simulator*.deb /tmp
 COPY --from=poet-core-builder /project/consensus/poet/python3-sawtooth-poet-core*.deb /tmp
 COPY --from=poet-cli-builder /project/consensus/poet/python3-sawtooth-poet-cli*.deb /tmp
+COPY --from=sawtooth-sdk-python-builder /project/sdk/python3-sawtooth*.deb /tmp
 
 COPY --from=sawtooth-validator-builder /project/python3-sawtooth-validator*.deb /tmp
 


### PR DESCRIPTION
Poet-core now depends on sawtooth-sdk, but not validator.
Poet-core is included in the validator build so that the poet-cli
is available in the validator, so sawtooth-sdk must be included.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>