### PR TITLE
Add block_info to pythonpath for validators

### DIFF
--- a/integration/sawtooth_integration/docker/test_poet_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_poet_liveness.yaml
@@ -127,7 +127,8 @@ services:
     \""
     stop_signal: SIGKILL
     environment:
-      PYTHONPATH: "/project/sawtooth-core/sdk/python"
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/families/block_info"
 
   validator-1:
     build:
@@ -147,6 +148,8 @@ services:
         sawtooth-validator -v
     \""
     stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
 
   validator-2:
     build:
@@ -166,6 +169,8 @@ services:
         sawtooth-validator -v
     \""
     stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
 
   validator-3:
     build:
@@ -185,6 +190,8 @@ services:
         sawtooth-validator -v
     \""
     stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
 
   validator-4:
     build:
@@ -204,6 +211,8 @@ services:
         sawtooth-validator -v
     \""
     stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
 
   poet-0:
     image: poet-python-local:$ISOLATION_ID


### PR DESCRIPTION
Adds block_info transaction family to the Python path for validators in
test_poet_liveness.yaml to expose block_info batch injector.

Signed-off-by: Logan Seeley <seeley@bitwise.io>