### PR TITLE
Change consensus notification lifecycle

### DIFF
--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -53,11 +53,13 @@ class ConsensusServiceHandler(Handler):
         request_type,
         response_class,
         response_type,
+        handler_status=HandlerStatus.RETURN
     ):
         self._request_class = request_class
         self._request_type = request_type
         self._response_class = response_class
         self._response_type = response_type
+        self._handler_status = handler_status
 
     def handle_request(self, request, response):
         raise NotImplementedError()
@@ -91,7 +93,7 @@ class ConsensusServiceHandler(Handler):
             self.handle_request(request, response)
 
         return HandlerResult(
-            status=HandlerStatus.RETURN,
+            status=self._handler_status,
             message_out=response,
             message_type=self._response_type)
 

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -80,14 +80,21 @@ class ConsensusProxy:
     # Using chain controller
     def check_blocks(self, block_ids):
         try:
-            blocks = [
+            for block_id in block_ids:
                 self._block_cache[block_id.hex()]
+        except KeyError as key_error:
+            raise UnknownBlock(key_error.args[0])
+
+    def get_block_statuses(self, block_ids):
+        """Returns a list of tuples of (lblock id, BlockStatus) pairs.
+        """
+        try:
+            return [
+                (block_id.hex(), self._block_cache[block_id.hex()].status)
                 for block_id in block_ids
             ]
         except KeyError as key_error:
             raise UnknownBlock(key_error.args[0])
-
-        self._chain_controller.submit_blocks_for_verification(blocks)
 
     def commit_block(self, block_id):
         try:

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -20,6 +20,7 @@ def add(
         dispatcher,
         thread_pool,
         consensus_proxy,
+        consensus_notifier,
 ):
 
     handler = handlers.ConsensusRegisterHandler(consensus_proxy)
@@ -44,6 +45,10 @@ def add(
     dispatcher.add_handler(handler.request_type, handler, thread_pool)
 
     handler = handlers.ConsensusCheckBlocksHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCheckBlocksNotifier(
+        consensus_proxy, consensus_notifier)
     dispatcher.add_handler(handler.request_type, handler, thread_pool)
 
     handler = handlers.ConsensusCommitBlockHandler(consensus_proxy)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -383,7 +383,10 @@ class Validator(object):
             state_view_factory=state_view_factory)
 
         consensus_handlers.add(
-            consensus_dispatcher, consensus_thread_pool, consensus_proxy)
+            consensus_dispatcher,
+            consensus_thread_pool,
+            consensus_proxy,
+            consensus_notifier)
 
         self._consensus_dispatcher = consensus_dispatcher
         self._consensus_service = consensus_service

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -477,30 +477,36 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
     }
 
     pub fn on_block_received(&mut self, block: BlockWrapper) -> Result<(), ChainControllerError> {
-        {
-            // Only hold this lock while modifying chain state
-            let mut state = self.state
-                .write()
-                .expect("No lock holder should have poisoned the lock");
+        let mut state = self.state
+            .write()
+            .expect("No lock holder should have poisoned the lock");
 
-            if state.has_block(block.header_signature()) {
-                return Ok(());
-            }
-
-            if state.chain_head.is_none() {
-                if let Err(err) = state.set_genesis(&self.chain_head_lock, block.clone()) {
-                    warn!(
-                        "Unable to set chain head; genesis block {} is not valid: {:?}",
-                        block.header_signature(),
-                        err
-                    );
-                }
-                return Ok(());
-            }
-
-            state.block_cache.put(block.clone());
+        if state.has_block(block.header_signature()) {
+            return Ok(());
         }
-        self.consensus_notifier.notify_block_new(&block);
+
+        if state.chain_head.is_none() {
+            if let Err(err) = state.set_genesis(&self.chain_head_lock, block.clone()) {
+                warn!(
+                    "Unable to set chain head; genesis block {} is not valid: {:?}",
+                    block.header_signature(),
+                    err
+                    );
+            }
+            return Ok(());
+        }
+
+        state.block_cache.put(block.clone());
+        let sender = self.validation_result_sender
+            .as_ref()
+            .expect(
+                "Attempted to submit blocks for validation before starting the chain controller",
+                )
+            .clone();
+
+        state.block_validator
+            .submit_blocks_for_verification(&[block], sender);
+
         Ok(())
     }
 
@@ -543,13 +549,6 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             COLLECTOR.counter("ChainController.blocks_considered_count", None, None);
         blocks_considered_count.inc();
 
-        if block.status == BlockStatus::Valid {
-            self.consensus_notifier
-                .notify_block_valid(block.header_signature());
-        } else {
-            self.consensus_notifier
-                .notify_block_invalid(block.header_signature());
-        }
         // Reset the block in the cache with a valid status (which otherwise
         // would be lost)
         //
@@ -558,6 +557,9 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             .expect("No lock holder should have poisoned the lock")
             .block_cache
             .put(block.clone());
+
+        self.consensus_notifier
+            .notify_block_new(block);
     }
 
     fn handle_block_commit(&mut self, block: &BlockWrapper) -> Result<(), ChainControllerError> {


### PR DESCRIPTION
Change when the validator to notify the consensus engine about new blocks to after the block has been validated.