### PR TITLE
Fix bytes -> string -> bytes conversion

### DIFF
--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -70,9 +70,8 @@ class ConsensusProxy:
         return self._block_publisher.summarize_block()
 
     def finalize_block(self, consensus_data):
-        return bytes.fromhex(
-            self._block_publisher.finalize_block(
-                consensus=consensus_data))
+        return self._block_publisher.finalize_block(
+            consensus=consensus_data)
 
     def cancel_block(self):
         self._block_publisher.cancel_block()

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -284,7 +284,7 @@ class BlockPublisher(OwnedPointer):
             ctypes.c_bool(force),
             ctypes.byref(c_result), ctypes.byref(c_result_len))
 
-        return ffi.from_c_bytes(c_result, c_result_len).decode()
+        return ffi.from_c_bytes(c_result, c_result_len)
 
     def initialize_block(self, block):
         self._py_call("initialize_block", ctypes.py_object(block))


### PR DESCRIPTION
The BlockPublisher python ffi was converting bytes into string and then
the proxy was converting the string back to bytes interpreting it as
hex.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>