### PR TITLE
Fix consensus proxy for settings_get unused variable

### DIFF
--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -140,12 +140,12 @@ class ConsensusProxy:
         result = []
         for setting in settings:
             try:
-                value = settings_view.get_setting(key)
+                value = settings_view.get_setting(setting)
             except KeyError:
                 # if the key is missing, leave it out of the response
                 continue
 
-            result.append((key, value))
+            result.append((setting, value))
 
         return result
 


### PR DESCRIPTION
Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>

This was found running `test_block_info_injector`.