### PR TITLE
Add timeouts to test_poet_liveness requests

### DIFF
--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -75,7 +75,7 @@ class TestPoetLive(unittest.TestCase):
 
 def get_block(node):
     try:
-        result = requests.get((URL % node) + "/blocks?count=1")
+        result = requests.get((URL % node) + "/blocks?count=1", timeout=1.0)
         result = result.json()
         try:
             return result["data"][0]
@@ -87,7 +87,7 @@ def get_block(node):
 
 def get_chain(node):
     try:
-        result = requests.get((URL % node) + "/blocks")
+        result = requests.get((URL % node) + "/blocks", timeout=1.0)
         result = result.json()
         try:
             return result["data"]


### PR DESCRIPTION
If 1+ validator stops responding the whole test will hang, causing
anyone debugging not to have logging of number of blocks. This commit
adds in a timeout on each `get` request so that the test won't hang.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>