### PR TITLE
Fixes to poet engine to catch exceptions

### DIFF
--- a/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
+++ b/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
@@ -171,7 +171,7 @@ class PoetEngine(Engine):
 
         while True:
             try:
-                type_tag, data = updates.get(timeout=1)
+                type_tag, data = updates.get(timeout=0.1)
             except queue.Empty:
                 pass
             else:

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -408,6 +408,8 @@ class BlockValidator(object):
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception(
                 "Block validation failed with unexpected error: %s", block)
+        else:
+            callback(block)
 
         try:
             blocks_now_ready = self._release_pending(block)
@@ -417,7 +419,6 @@ class BlockValidator(object):
                 "Submitting pending blocks failed with unexpected error: %s",
                 block)
 
-        callback(block)
 
 
 class BlockScheduler:


### PR DESCRIPTION
This PR:
1: Catches an exception in PoET in the Engine and proceeds as if the check failed
2: Increases the check publish frequency from a 1 second wait time to 100 ms wait time.
3: Only send a "notify block new" to the consensus engine if the block verification in the block validator succeeds.