### PR TITLE
More poet engine fixes

### DIFF
--- a/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
+++ b/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
@@ -106,8 +106,10 @@ class PoetEngine(Engine):
     def _summarize_block(self):
         try:
             return self._service.summarize_block()
-        except (exceptions.InvalidState, exceptions.BlockNotReady) as err:
+        except exceptions.InvalidState as err:
             LOGGER.warning(err)
+            return None
+        except exceptions.BlockNotReady:
             return None
 
     def _finalize_block(self):

--- a/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
+++ b/sdk/examples/poet_python/sawtooth_poet_engine/engine.py
@@ -204,9 +204,13 @@ class PoetEngine(Engine):
         if self._building:
             if self._check_publish_block():
                 block_id = self._finalize_block()
-                LOGGER.info("Published block %s", block_id.hex())
-                self._published = True
-                self._building = False
+                if block_id:
+                    LOGGER.info("Published block %s", block_id.hex())
+                    self._published = True
+                    self._building = False
+                else:
+                    self._cancel_block()
+                    self._building = False
 
     def _handle_new_block(self, block):
         block = PoetBlock(block)


### PR DESCRIPTION
The "Handle poet failure to finalize block" commit fixes this error:
```Jun 27 14:59:26 lr7c-node4 poet-engine[22037]: [2018-06-27 14:59:26.590 DEBUG    engine] Block not ready to be summarized
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]: [2018-06-27 14:59:27.600 INFO     engine] Block summary: e1f160e52544233c173a0f9853e4cb392c170f88415d24568700e23cbdc8c6ab
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]: [2018-06-27 14:59:27.603 ERROR    poet_block_publisher] Failed to create wait certificate: Cannot create wait certificate because timer has timed out
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]: [2018-06-27 14:59:27.604 ERROR    zmq_driver] Uncaught engine exception
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]: Traceback (most recent call last):
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:   File "/usr/lib/python3/dist-packages/sawtooth_sdk/consensus/zmq_driver.py", line 62, in start
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:     peers)
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:   File "/usr/lib/python3/dist-packages/sawtooth_poet_engine/engine.py", line 196, in start
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:     self._try_to_publish()
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:   File "/usr/lib/python3/dist-packages/sawtooth_poet_engine/engine.py", line 209, in _try_to_publish
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]:     LOGGER.info("Published block %s", block_id.hex())
Jun 27 14:59:27 lr7c-node4 poet-engine[22037]: AttributeError: 'NoneType' object has no attribute 'hex'```